### PR TITLE
Support argo config overrides via envvars

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -25,6 +25,23 @@ pip install -v --editable .[dev]
 To use the CLI to run simple ogdc recipes with argo:
 
 ```
+$ ogdc-runner submit-and-wait ~/code/ogdc-recipes/recipes/seal-tags/
+Successfully submitted recipe with workflow name seal-tags-6gxfw
+Workflow status: Running
+Workflow status: Running
+Workflow status: Running
+Workflow status: Succeeded
+```
+
+### Using a local docker image for workflow execution
+
+The `ogdc-runner` supports using a local `ogdc-runner` image for development
+purposes (e.g., you want to change and test something about the image without
+needing to release it to the GHCR).
+
+First, build a local image:
+
+```
 docker build . -t ogdc-runner
 ```
 
@@ -32,15 +49,11 @@ docker build . -t ogdc-runner
 > that it is available to the Argo deployment on the developer's local machine.
 > Check that you have the correct context selected with `docker context ls`.
 
-Now use the CLI to submit a simple ogdc recipe:
+Next, set the `ENVIRONMENT` envvar to `dev`. This will tell `ogdc-runner` to use
+the locally built image instead of the one hosted on the GHCR:
 
 ```
-$ ogdc-runner submit-and-wait ~/code/ogdc-recipes/recipes/seal-tags/
-Successfully submitted recipe with workflow name seal-tags-6gxfw
-Workflow status: Running
-Workflow status: Running
-Workflow status: Running
-Workflow status: Succeeded
+export ENNVIRONMENT=dev
 ```
 
 ## Testing, linting, rendering docs with Nox

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -24,9 +24,6 @@ pip install -v --editable .[dev]
 
 To use the CLI to run simple ogdc recipes with argo:
 
-- Build the `ogdc-runner` docker image (TODO: add GHA for building and pushing
-  to ghcr!):
-
 ```
 docker build . -t ogdc-runner
 ```

--- a/src/ogdc_runner/argo.py
+++ b/src/ogdc_runner/argo.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 from hera.shared import global_config
 from hera.workflows import (
     Container,
@@ -7,25 +9,49 @@ from hera.workflows import (
     WorkflowsService,
 )
 
-# Argo-related constants.
-# TODO: move these to `constants.py`? And/or allow override via envvars or some
-# other config.
-ARGO_NAMESPACE = "argo-helm"
-ARGO_SERVICE_ACCOUNT_NAME = "argo-workflow"
-ARGO_WORKFLOW_SERVICE_URL = "http://localhost:2746"
 
-# https://hera.readthedocs.io/en/stable/examples/workflows/misc/global_config/
-global_config.namespace = ARGO_NAMESPACE
-global_config.service_account_name = ARGO_SERVICE_ACCOUNT_NAME
+def _configure_argo_settings() -> WorkflowsService:
+    """Configure argo settings for the OGDC and return an argo WorkflowsService instance.
 
-# TODO: this is dev-specific config!
-global_config.set_class_defaults(
-    Container,
-    image_pull_policy="Never",
-)
-global_config.image = "ogdc-runner"
+    Environment variables can be used to override common defaults in dev:
 
-ARGO_WORKFLOW_SERVICE = WorkflowsService(host=ARGO_WORKFLOW_SERVICE_URL)
+    * ARGO_NAMESPACE: defines the kubernetes namespace the OGDC argo instance is deployed to.
+    * ARGO_SERVICE_ACCOUNT_NAME: defines the Argo service account with permissions to execute workflows.
+    * ARGO_WORKFLOWS_SERVICE_URL: the OGDC Argo workflows service URL.
+
+    Returns a `WorkflowsService` instance.
+
+    Note that this function is expected to be run only once (automatically) at
+    module import time.
+    """
+
+    # set argo constants from envvars, falling back on dev settings
+    argo_namespace = (os.environ.get("ARGO_NAMESPACE", "argo-helm"),)
+    argo_service_account_name = (
+        os.environ.get("ARGO_SERVICE_ACCOUNT_NAME", "argo-workflow"),
+    )
+    argo_workflows_service_url = (
+        os.environ.get("ARGO_WORKFLOWS_SERVICE_URL", "http://localhost:2746"),
+    )
+
+    # Set global defaults for argo
+    # https://hera.readthedocs.io/en/stable/examples/workflows/misc/global_config/
+    global_config.namespace = argo_namespace
+    global_config.service_account_name = argo_service_account_name
+
+    # TODO: this is dev-specific config!
+    global_config.set_class_defaults(
+        Container,
+        image_pull_policy="Never",
+    )
+    global_config.image = "ogdc-runner"
+
+    workflows_service = WorkflowsService(host=argo_workflows_service_url)
+
+    return workflows_service
+
+
+ARGO_WORKFLOW_SERVICE = _configure_argo_settings()
 
 
 def get_workflow_status(workflow_name: str) -> str | None:

--- a/src/ogdc_runner/argo.py
+++ b/src/ogdc_runner/argo.py
@@ -31,12 +31,12 @@ def _configure_argo_settings() -> WorkflowsService:
     """
 
     # set argo constants from envvars, falling back on dev settings
-    argo_namespace = (os.environ.get("ARGO_NAMESPACE", "argo-helm"),)
-    argo_service_account_name = (
-        os.environ.get("ARGO_SERVICE_ACCOUNT_NAME", "argo-workflow"),
+    argo_namespace = os.environ.get("ARGO_NAMESPACE", "argo-helm")
+    argo_service_account_name = os.environ.get(
+        "ARGO_SERVICE_ACCOUNT_NAME", "argo-workflow"
     )
-    argo_workflows_service_url = (
-        os.environ.get("ARGO_WORKFLOWS_SERVICE_URL", "http://localhost:2746"),
+    argo_workflows_service_url = os.environ.get(
+        "ARGO_WORKFLOWS_SERVICE_URL", "http://localhost:2746"
     )
     ogdc_runner_image_tag = os.environ.get("OGDC_RUNNER_IMAGE_TAG", "latest")
 

--- a/tests/integration/test_argo_workflow.py
+++ b/tests/integration/test_argo_workflow.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from ogdc_runner.argo import ARGO_WORKFLOW_SERVICE
 from ogdc_runner.recipe.simple import make_simple_workflow
 
 SIMPLE_RECIPE_TEST_PATH = Path(__file__).parent / "test_recipe"
@@ -18,3 +19,6 @@ def test_simple_argo_workflow():
     submitted_wf = workflow.create(wait=True)
     assert submitted_wf.status  # type: ignore[union-attr]
     assert submitted_wf.status.phase == "Succeeded"  # type: ignore[union-attr]
+    # Cleanup the test workflow
+    if workflow.name:
+        ARGO_WORKFLOW_SERVICE.delete_workflow(workflow.name)

--- a/tests/unit/test_argo.py
+++ b/tests/unit/test_argo.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 from hera.shared import global_config
+from hera.workflows import Container
 
 from ogdc_runner.argo import _configure_argo_settings
 
 
 def test__configure_argo_settings_envvar_override(monkeypatch):
+    """Test `_configure_argo_settings` envvar overrides in a dev environment"""
     for envvar in (
         "ARGO_NAMESPACE",
         "ARGO_SERVICE_ACCOUNT_NAME",
         "ARGO_WORKFLOWS_SERVICE_URL",
+        "OGDC_RUNNER_IMAGE_TAG",
     ):
         monkeypatch.setenv(envvar, f"{envvar.lower()}_test")
 
@@ -18,3 +21,15 @@ def test__configure_argo_settings_envvar_override(monkeypatch):
     assert workflow_service.host[0] == "argo_workflows_service_url_test"
     assert global_config.namespace[0] == "argo_namespace_test"
     assert global_config.service_account_name[0] == "argo_service_account_name_test"
+    assert (
+        global_config.image
+        == "ghcr.io/qgreenland-net/ogdc-runner:ogdc_runner_image_tag_test"
+    )
+
+
+def test__configure_argo_settings_dev(monkeypatch):
+    """Test `_configure_argo_settings` dev environment"""
+    monkeypatch.setenv("ENVIRONMENT", "dev")
+    _configure_argo_settings()
+    assert global_config.image == "ogdc-runner"
+    assert Container().image_pull_policy == "Never"

--- a/tests/unit/test_argo.py
+++ b/tests/unit/test_argo.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from hera.shared import global_config
+
+from ogdc_runner.argo import _configure_argo_settings
+
+
+def test__configure_argo_settings_envvar_override(monkeypatch):
+    for envvar in (
+        "ARGO_NAMESPACE",
+        "ARGO_SERVICE_ACCOUNT_NAME",
+        "ARGO_WORKFLOWS_SERVICE_URL",
+    ):
+        monkeypatch.setenv(envvar, f"{envvar.lower()}_test")
+
+    workflow_service = _configure_argo_settings()
+
+    assert workflow_service.host[0] == "argo_workflows_service_url_test"
+    assert global_config.namespace[0] == "argo_namespace_test"
+    assert global_config.service_account_name[0] == "argo_service_account_name_test"

--- a/tests/unit/test_argo.py
+++ b/tests/unit/test_argo.py
@@ -18,9 +18,9 @@ def test__configure_argo_settings_envvar_override(monkeypatch):
 
     workflow_service = _configure_argo_settings()
 
-    assert workflow_service.host[0] == "argo_workflows_service_url_test"
-    assert global_config.namespace[0] == "argo_namespace_test"
-    assert global_config.service_account_name[0] == "argo_service_account_name_test"
+    assert workflow_service.host == "argo_workflows_service_url_test"
+    assert global_config.namespace == "argo_namespace_test"
+    assert global_config.service_account_name == "argo_service_account_name_test"
     assert (
         global_config.image
         == "ghcr.io/qgreenland-net/ogdc-runner:ogdc_runner_image_tag_test"


### PR DESCRIPTION
Resolves #32

Allows overriding default config values for Argo (e.g., the namespace, workflow service url, etc.) and adds support for "dev" environment (where local docker image can be used for workflow executions) via envvars. 