### PR TITLE
Refactors for argo workflow submission

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -27,7 +27,7 @@ pip install -v --editable .[dev]
 To use the CLI to run simple ogdc recipes with argo:
 
 ```
-$ ogdc-runner submit-and-wait ~/code/ogdc-recipes/recipes/seal-tags/
+$ ogdc-runner submit --wait ~/code/ogdc-recipes/recipes/seal-tags/
 Successfully submitted recipe with workflow name seal-tags-6gxfw
 Workflow status: Running
 Workflow status: Running

--- a/src/ogdc_runner/__main__.py
+++ b/src/ogdc_runner/__main__.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import time
-
 import click
 
 from ogdc_runner.argo import get_workflow_status, submit_workflow
@@ -20,15 +18,6 @@ def cli() -> None:
     """A tool for submitting data transformation recipes to OGDC for execution."""
 
 
-def _submit_workflow(recipe_path: str) -> str:
-    workflow = make_simple_workflow(
-        recipe_dir=recipe_path,
-    )
-    workflow_name = submit_workflow(workflow)
-    print(f"Successfully submitted recipe with workflow name {workflow_name}")
-    return workflow_name
-
-
 @cli.command
 @recipe_path
 def submit(recipe_path: str) -> None:
@@ -38,7 +27,10 @@ def submit(recipe_path: str) -> None:
     RECIPE-PATH: Path to the recipe file. Use either a local path (e.g., '/ogdc-recipes/recipes/seal-tags')
     or an fsspec-compatible GitHub string (e.g., 'github://qgreenland-net:ogdc-recipes@main/recipes/seal-tags').
     """
-    _submit_workflow(recipe_path)
+    workflow = make_simple_workflow(
+        recipe_dir=recipe_path,
+    )
+    submit_workflow(workflow)
 
 
 @cli.command
@@ -62,13 +54,7 @@ def submit_and_wait(recipe_path: str) -> None:
     RECIPE-PATH: Path to the recipe file. Use either a local path (e.g., '/ogdc-recipes/recipes/seal-tags')
     or an fsspec-compatible GitHub string (e.g., 'github://qgreenland-net:ogdc-recipes@main/recipes/seal-tags').
     """
-    workflow_name = _submit_workflow(recipe_path)
-
-    while True:
-        status = get_workflow_status(workflow_name)
-        if status:
-            print(f"Workflow status: {status}")
-            # Terminal states
-            if status in ("Succeeded", "Failed"):
-                break
-        time.sleep(5)
+    workflow = make_simple_workflow(
+        recipe_dir=recipe_path,
+    )
+    submit_workflow(workflow, wait=True)

--- a/src/ogdc_runner/__main__.py
+++ b/src/ogdc_runner/__main__.py
@@ -5,13 +5,6 @@ import click
 from ogdc_runner.argo import get_workflow_status, submit_workflow
 from ogdc_runner.recipe.simple import make_simple_workflow
 
-recipe_path = click.argument(
-    "recipe_path",
-    required=True,
-    metavar="RECIPE-PATH",
-    type=str,
-)
-
 
 @click.group
 def cli() -> None:
@@ -19,8 +12,19 @@ def cli() -> None:
 
 
 @cli.command
-@recipe_path
-def submit(recipe_path: str) -> None:
+@click.argument(
+    "recipe_path",
+    required=True,
+    metavar="RECIPE-PATH",
+    type=str,
+)
+@click.option(
+    "--wait",
+    is_flag=True,
+    default=False,
+    help="Wait for recipe execution to complete.",
+)
+def submit(recipe_path: str, wait: bool) -> None:
     """
     Submit a recipe to OGDC for execution.
 
@@ -30,7 +34,7 @@ def submit(recipe_path: str) -> None:
     workflow = make_simple_workflow(
         recipe_dir=recipe_path,
     )
-    submit_workflow(workflow)
+    submit_workflow(workflow, wait=wait)
 
 
 @cli.command
@@ -43,18 +47,3 @@ def check_workflow_status(workflow_name: str) -> None:
     """Render and submit a recipe to OGDC for execution."""
     status = get_workflow_status(workflow_name)
     print(f"Workflow {workflow_name} has status {status}.")
-
-
-@cli.command
-@recipe_path
-def submit_and_wait(recipe_path: str) -> None:
-    """
-    Submit a recipe to OGDC for execution and wait until completion.
-
-    RECIPE-PATH: Path to the recipe file. Use either a local path (e.g., '/ogdc-recipes/recipes/seal-tags')
-    or an fsspec-compatible GitHub string (e.g., 'github://qgreenland-net:ogdc-recipes@main/recipes/seal-tags').
-    """
-    workflow = make_simple_workflow(
-        recipe_dir=recipe_path,
-    )
-    submit_workflow(workflow, wait=True)


### PR DESCRIPTION
This PR does some light refactoring of how we submit workflows to argo, and simplifies the CLI. Instead of two separate commands for submitting workflows (`submit` and `submit-and-wait`), there is now just the `submit` CLI, which takes an optional `--wait` flag that will replicate the behavior of `submit-and-wait`.

These changes came up while exploring options for #45 . Use case is that our code should be able to submit a workflow, wait for it to complete, and then initiate another follow-on workflow. E.g., a user submits a data transformation workflow, then our viz-workflow gets kicked off to visualize the result.