### PR TITLE
Remove broken badge links from repo README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,9 @@
 
 <!-- SPHINX-START -->
 
-[![Actions Status][actions-badge]][actions-link]
 [![Documentation Status][rtd-badge]][rtd-link]
 
 [![PyPI version][pypi-version]][pypi-link]
-[![Conda-Forge][conda-badge]][conda-link]
 [![PyPI platforms][pypi-platforms]][pypi-link]
 
 [![GitHub Discussion][github-discussions-badge]][github-discussions-link]
@@ -18,10 +16,7 @@ See the [ogdc-runner ReadTheDocs](https://ogdc-runner.readthedocs.io/) for
 detailed documentation on how to use and contribute to the `ogdc-runner`.
 
 <!-- prettier-ignore-start -->
-[actions-badge]:            https://github.com/qgreenland-net/ogdc-runner/workflows/CI/badge.svg
 [actions-link]:             https://github.com/qgreenland-net/ogdc-runner/actions
-[conda-badge]:              https://img.shields.io/conda/vn/conda-forge/ogdc-runner
-[conda-link]:               https://github.com/conda-forge/ogdc-runner-feedstock
 [github-discussions-badge]: https://img.shields.io/static/v1?label=Discussions&message=Ask&color=blue&logo=github
 [github-discussions-link]:  https://github.com/qgreenland-net/ogdc-runner/discussions
 [pypi-link]:                https://pypi.org/project/ogdc-runner/


### PR DESCRIPTION
These were added/included automatically via the scientific python template we used to initialize this repo.

* Remove actions status badge, which does not work. The status of actions is clear enough from the GH interface.
* Remove conda badge. We are not publishing to conda.