### PR TITLE
Remove `image_pull_policy="Never"` in local env

### DIFF
--- a/src/ogdc_runner/argo.py
+++ b/src/ogdc_runner/argo.py
@@ -72,9 +72,9 @@ class ArgoManager:
 
         image_pull_policy = "IfNotPresent"
         if is_dev_environment:
+            # In dev, we expect the `latest` image to be used, so we always want
+            # the latest pulled and updated.
             image_pull_policy = "Always"
-        elif is_local_environment:
-            image_pull_policy = "Never"
 
         # Argo workflows service URL
         workflows_service_url = os.environ.get(

--- a/tests/unit/test_argo.py
+++ b/tests/unit/test_argo.py
@@ -25,7 +25,7 @@ def reload_argo_module(_: object) -> Any:
 
 env_test_settings = [
     # when ENVIRONMENT=local, the `ogdc-runner` image should be used
-    ("local", "ogdc-runner:ogdc_runner_image_tag_test", "Never"),
+    ("local", "ogdc-runner:ogdc_runner_image_tag_test", "IfNotPresent"),
     # when ENVIRONMENT=production, the `ogdc-runner` image hosted on ghcr should be used
     (
         "production",
@@ -71,7 +71,7 @@ def test__configure_argo_settings_dev(monkeypatch):
 
     argo = reload_argo_module(monkeypatch)
     assert argo.global_config.image == "ogdc-runner:latest"
-    assert Container().image_pull_policy == "Never"
+    assert Container().image_pull_policy == "IfNotPresent"
     assert argo.global_config.namespace == "qgnet"
     assert argo.global_config.service_account_name == "argo-workflow"
 
@@ -112,7 +112,7 @@ def test_ARGO_MANAGER_config_access(monkeypatch):
     )
     assert config.runner_image == "ogdc-runner"
     assert config.runner_image_tag == "latest"
-    assert config.image_pull_policy == "Never"
+    assert config.image_pull_policy == "IfNotPresent"
 
 
 def test_ARGO_MANAGER_update_image(monkeypatch):


### PR DESCRIPTION
Skaffold now handles ensuring the locally-built ogdc-runner image is deployed to the cluster, which was the reason the image pull policy was originally setup to "Never" for local dev - to ensure that only the locally & manually built docker image was used. This is OBE.

This was breaking the integration tests for viz workflow (#129) when  `ENVIRONMENT=local`. The viz workflow uses other images (e.g., `alpine`) that are not managed by skaffold/placed on the cluster manually.