### PR TITLE
Remove unused `image` config

### DIFF
--- a/src/ogdc_runner/models/recipe_config.py
+++ b/src/ogdc_runner/models/recipe_config.py
@@ -285,12 +285,6 @@ class RecipeMeta(OgdcBaseModel):
         PvcRecipeOutput()
     )
 
-    # Optional Docker image (supports both local and hosted images)
-    # Examples: "my-local-image", "ghcr.io/owner/image:latest"
-    image: str | None = Field(
-        default=None, description="Docker image with optional tag"
-    )
-
 
 class RecipeConfig(RecipeMeta):
     """Model for a recipe's configuration.

--- a/tests/test_viz_workflow_recipe_dir/meta.yml
+++ b/tests/test_viz_workflow_recipe_dir/meta.yml
@@ -8,4 +8,3 @@ input:
       type: "url"
 output:
   type: "pvc"
-image: "ghcr.io/permafrostdiscoverygateway/pdgworkflow:latest"


### PR DESCRIPTION
This is currently unused. In the future, if the need to configure the docker image(s) used during argo workflow is needed at the recipe level, that should be a part of the workflow configuration.

Related: https://github.com/QGreenland-Net/ogdc-recipes/pull/11