### PR TITLE
ci: support PyPI Core Metadata 2.5

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: "hynek/build-and-inspect-python-package@v2"
+      - uses: "hynek/build-and-inspect-python-package@2abe76da66d0a6a4a227101f9348ee855797cfa5" # v3.0.1
 
   #######################################################################
   # Build Docker
@@ -80,7 +80,7 @@ jobs:
           name: "Packages"
           path: "dist"
 
-      - uses: "pypa/gh-action-pypi-publish@release/v1"
+      - uses: "pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33" # v1.14.2
 
   #######################################################################
   # Publish Docker


### PR DESCRIPTION
## Summary
- upgrade `hynek/build-and-inspect-python-package` to v3.0.1, which bundles Twine 7
- pin `pypa/gh-action-pypi-publish` to v1.14.2 for Metadata 2.5 uploads
- pin both third-party actions to their release commit SHAs

## Problem
The v0.4.1 release build emits Core Metadata 2.5. The existing `build-and-inspect-python-package@v2` action bundles Twine 6.2.0, which rejects it with:

```
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

## Verification
- reproduced the failure with the v0.4.1 source distribution and Twine 6.2.0
- verified the same wheel and sdist pass `twine check --strict` with Twine 7.0.0
- `uvx pre-commit run --files .github/workflows/publish.yml`
- confirmed both pinned action commit SHAs resolve to the intended releases

Failed run: https://github.com/QGreenland-Net/ogdc-runner/actions/runs/32294488859/job/96202541537